### PR TITLE
Gitignore files and inventories as files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .vaultpass
 .environment
-files/
-inventories/
+files
+inventories


### PR DESCRIPTION
I figured I will make symbolic links 'files' and 'inventories', just
to avoid the mess of submodules or just copying over folders from upstream
link.