### PR TITLE
Sync images contents on remote

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -83,7 +83,7 @@
         mode: 0755
     - name: Copy local images folder contents on remote
       synchronize:
-        src: ~/images
+        src: ~/images/
         dest: /home/centos/images
     - name: Create link to network-infra files
       file:


### PR DESCRIPTION
Without slash, we get images folder created within images.