### PR TITLE
install scp for nxos_file_copy module on nodepool

### DIFF
--- a/nodepool.yml
+++ b/nodepool.yml
@@ -55,6 +55,7 @@
         - pexpect
         - ncclient
         - jxmlease
+        - scp
     - include_role:
         name: ansible-role-zookeeper
     - include_role:


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>
Install scp for nxos_file_copy module on nodepool