### PR TITLE
Add cron to delete older checkouts

### DIFF
--- a/dci-agent.yml
+++ b/dci-agent.yml
@@ -57,6 +57,12 @@
             minute: '0'
             job: source /etc/dci/feeders.sh &&  bash -c "cd /usr/share/dci/dci-feeders/ && ansible-playbook playbook.yml"
             user: centos
+        - name: Set cron for deleting old checouts
+          cron:
+            name: dci checkout cleanup
+            minute: '0'
+            job: 'find /home/centos/dci-workspace/ansible/ -mindepth 1 -maxdepth 1 -type d  -mtime +3 -exec rm -rf {} \;'
+            user: centos
 ####################
         - name: Set cron for running VyOS against Ansible devel
           cron:


### PR DESCRIPTION
To ensure we don't full up the disk delete checkouts that haven't been
used in a number of days.

The `hooks` touch the checkout directory to ensure the modified
time stamp is updated so we don't delete needed checkouts which was done in https://github.com/ansible/network-infra/pull/293